### PR TITLE
Add autodoc configuration and API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,26 @@
+API Reference
+=============
+
+SegmentationDataset
+-------------------
+
+.. automodule:: disell.SegmentationDataset
+   :members:
+
+Flood Fill Probabilities
+------------------------
+
+.. automodule:: disell.flood_fill_probabilities
+   :members:
+
+Segmentation Module
+-------------------
+
+.. automodule:: disell.segmentation_module
+   :members:
+
+Registration
+------------
+
+.. automodule:: disell.registration
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,12 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+import os
+import sys
+
+# Add project source directory to sys.path so autodoc can find modules
+sys.path.insert(0, os.path.abspath('../src'))
+
 project = 'disell'
 copyright = '2025, Johann Haack'
 author = 'Johann Haack'
@@ -14,7 +20,10 @@ release = '0.1.0'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+]
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,3 +15,5 @@ documentation for details.
    :maxdepth: 2
    :caption: Contents:
 
+   api
+


### PR DESCRIPTION
## Summary
- include autodoc & napoleon in Sphinx config
- add API reference skeleton using automodule directives
- link new API page from index

## Testing
- `sphinx-build -b html docs docs/_build/html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874942815c8321a6d2ea3b55e26633